### PR TITLE
feat(perpetual-launch): first commit forking launch-emp to launch a perp instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# Stub Package for Launching a New EMP
+# Stub Package for Launching a New Perpetual
 
-The purpose of this repository/package is to make it easy to customize your EMP deployment. Feel free to use this
+The purpose of this repository/package is to make it easy to customize your Perpetual deployment. Feel free to use this
 repository in place or fork and customize it.
 
 ## Install system dependencies
 
-You will need to install nodejs v12 (we recommend `nvm` to manage node versions) and yarn.
+You will need to install nodejs (we recommend the latest stable version, nodejs v14, and `nvm` to manage node versions) and yarn.
 
 Note: these additional dependencies are required -- you may or may not have them on your system already:
 
@@ -53,7 +53,7 @@ node index.js --gasprice 50 --url your.node.url.io --mnemonic "your mnemonic (12
 
 ## Customize the script
 
-The script should be fairly easy to read and understand. The primary use case for customization is modifying the empParams
-struct to customize the construction parameters for the EMP. See [the script](./index.js) for more details.
+The script should be fairly easy to read and understand. The primary use case for customization is modifying the perpetualParams
+struct to customize the construction parameters for the Perpetual. See [the script](./index.js) for more details.
 
 We encourage you to fork this repo and customize the script as you see fit!

--- a/index.js
+++ b/index.js
@@ -5,9 +5,25 @@ const { getAbi, getAddress } = require("@uma/core");
 // Optional arguments:
 // --url: node url, by default points at http://localhost:8545.
 // --mnemonic: an account mnemonic you'd like to use. The script will default to using the node's unlocked accounts.
+// Mandatory arguments:
+// --gasprice: gas price to use in GWEI
+// --priceFeedIdentifier: price identifier to use.
+// --collateralAddress: collateral token address.
+// --expirationTimestamp: timestamp that the contract will expire at.
+// --syntheticName: long name.
+// --syntheticSymbol: short name.
+// --minSponsorTokens: minimum sponsor position size
+
 const argv = require("minimist")(process.argv.slice(), {
-  string: ["url", "mnemonic"],
+  string: ["url", "mnemonic", "priceFeedIdentifier", "fundingRateIdentifier", "collateralAddress", "syntheticName", "syntheticSymbol", "minSponsorTokens"]
 });
+
+if (!argv.priceFeedIdentifier) throw "--priceFeedIdentifier required";
+if (!argv.fundingRateIdentifier) throw "--fundingRateIdentifier required";
+if (!argv.collateralAddress) throw "--collateralAddress required";
+if (!argv.syntheticName) throw "--syntheticName required";
+if (!argv.syntheticSymbol) throw "--syntheticSymbol required";
+if (!argv.minSponsorTokens) throw "--minSponsorTokens required";
 if (!argv.gasprice) throw "--gasprice required (in GWEI)";
 if (typeof argv.gasprice !== "number") throw "--gasprice must be a number";
 if (argv.gasprice < 1 || argv.gasprice > 1000) throw "--gasprice must be between 1 and 1000 (GWEI)";
@@ -37,16 +53,16 @@ if (argv.gasprice < 1 || argv.gasprice > 1000) throw "--gasprice must be between
 
   // Example Perpetual Parameters. Customize these.
   const perpetualParams = {
-    collateralAddress: "0xd0a1e359811322d97991e03f863a0c30c2cf029c", // Kovan WETH address. Mainnet WETH is: 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.
-    priceFeedIdentifier: padRight(utf8ToHex("USDETH"), 64), // Using the USDETH price.
-    fundingRateIdentifier: padRight(utf8ToHex("USDETH"), 64), // Using the USDETH funding rate identifier.
-    syntheticName: "uUSDwETH Perpetual Synthetic Token", // Long name.
-    syntheticSymbol: "uUSDwETH", // Short name.
+    collateralAddress: argv.collateralAddress.toString(), // Collateral token address.
+    priceFeedIdentifier: padRight(utf8ToHex(argv.priceFeedIdentifier.toString()), 64), // Price identifier to use.
+    fundingRateIdentifier: padRight(utf8ToHex(argv.fundingRateIdentifier.toString()), 64), // Funding rate to use.
+    syntheticName: argv.syntheticName, // Long name.
+    syntheticSymbol: argv.syntheticSymbol, // Short name.
     collateralRequirement: { rawValue: toWei("1.25") }, // 125% collateral req.
     disputeBondPercentage: { rawValue: toWei("0.1") }, // 10% dispute bond.
     sponsorDisputeRewardPercentage: { rawValue: toWei("0.05") }, // 5% reward for sponsors who are disputed invalidly
     disputerDisputeRewardPercentage: { rawValue: toWei("0.2") }, // 20% reward for correct disputes.
-    minSponsorTokens: { rawValue: toWei("100") }, // Min sponsor position size of 100 synthetic tokens.
+    minSponsorTokens: { rawValue: toWei(argv.minSponsorTokens.toString()) }, // Min sponsor position.
     tokenScaling: { rawValue: toWei("1") }, // Token scaling.
     liquidationLiveness: 7200, // 2 hour liquidation liveness.
     withdrawalLiveness: 7200 // 2 hour withdrawal liveness.

--- a/index.js
+++ b/index.js
@@ -35,26 +35,35 @@ if (argv.gasprice < 1 || argv.gasprice > 1000) throw "--gasprice must be between
   const account = accounts[0];
   const networkId = await web3.eth.net.getId();
 
-  // Example EMP Parameters. Customize these.
-  const empParams = {
-    expirationTimestamp: "1640995200", // 01/01/2022 @ 0:00 (UTC)
+  // Example Perpetual Parameters. Customize these.
+  const perpetualParams = {
     collateralAddress: "0xd0a1e359811322d97991e03f863a0c30c2cf029c", // Kovan WETH address. Mainnet WETH is: 0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2.
     priceFeedIdentifier: padRight(utf8ToHex("USDETH"), 64), // Using the USDETH price.
-    syntheticName: "uUSDwETH Synthetic Token Expiring 1 January 2022", // Long name.
-    syntheticSymbol: "uUSDwETH-JAN", // Short name.
+    fundingRateIdentifier: padRight(utf8ToHex("USDETH"), 64), // Using the USDETH funding rate identifier.
+    syntheticName: "uUSDwETH Perpetual Synthetic Token", // Long name.
+    syntheticSymbol: "uUSDwETH", // Short name.
     collateralRequirement: { rawValue: toWei("1.25") }, // 125% collateral req.
-    disputeBondPct: { rawValue: toWei("0.1") }, // 10% dispute bond.
-    sponsorDisputeRewardPct: { rawValue: toWei("0.05") }, // 5% reward for sponsors who are disputed invalidly
-    disputerDisputeRewardPct: { rawValue: toWei("0.2") }, // 20% reward for correct disputes.
+    disputeBondPercentage: { rawValue: toWei("0.1") }, // 10% dispute bond.
+    sponsorDisputeRewardPercentage: { rawValue: toWei("0.05") }, // 5% reward for sponsors who are disputed invalidly
+    disputerDisputeRewardPercentage: { rawValue: toWei("0.2") }, // 20% reward for correct disputes.
     minSponsorTokens: { rawValue: toWei("100") }, // Min sponsor position size of 100 synthetic tokens.
+    tokenScaling: { rawValue: toWei("1") }, // Token scaling.
     liquidationLiveness: 7200, // 2 hour liquidation liveness.
-    withdrawalLiveness: 7200, // 2 hour withdrawal liveness.
-    excessTokenBeneficiary:  getAddress("Store", networkId), // UMA Store contract.
+    withdrawalLiveness: 7200 // 2 hour withdrawal liveness.
   };
 
-  const empCreator = new web3.eth.Contract(
-    getAbi("ExpiringMultiPartyCreator"),
-    getAddress("ExpiringMultiPartyCreator", networkId)
+  const configSettings = {
+    rewardRatePerSecond: { rawValue: "0" },
+    proposerBondPercentage: { rawValue: "0" },
+    timelockLiveness: 86400, // 1 day
+    maxFundingRate: { rawValue: web3.utils.toWei("0.00001") },
+    minFundingRate: { rawValue: web3.utils.toWei("-0.00001") },
+    proposalTimePastLimit: 0
+  };
+
+  const perpetualCreator = new web3.eth.Contract(
+    getAbi("PerpetualCreator"),
+    getAddress("PerpetualCreator", networkId)
   );
 
   // Transaction parameters
@@ -66,12 +75,13 @@ if (argv.gasprice < 1 || argv.gasprice > 1000) throw "--gasprice must be between
 
   // Simulate transaction to test before sending to the network.
   console.log("Simulating Deployment...");
-  const address = await empCreator.methods.createExpiringMultiParty(empParams).call(transactionOptions);
+  const address = await perpetualCreator.methods.createPerpetual(perpetualParams, configSettings).call(transactionOptions);
   console.log("Simulation successful. Expected Address:", address);
 
   // Since the simulated transaction succeeded, send the real one to the network.
-  const { transactionHash } = await empCreator.methods.createExpiringMultiParty(empParams).send(transactionOptions);
+  const { transactionHash } = await perpetualCreator.methods.createPerpetual(perpetualParams, configSettings).send(transactionOptions);
   console.log("Deployed in transaction:", transactionHash);
+  process.exit(0);
 })().catch((e) => {
   console.error(e);
   process.exit(1); // Exit with a nonzero exit code to signal failure.


### PR DESCRIPTION
Signed-off-by: John Shutt <john.d.shutt@gmail.com>

This forks the EMP Launch repo to launch the new Perpetual contract, and makes a few other minor improvements.

Currently untested, but if we do a new release of the core package (@uma/core@next), we could test it that way. It would include the new Kovan addresses, since those were just merged into master.

Once the contracts are launched on mainnet, and we re-release the core package, we could merge with the @uma/core dependency instead of @uma/core@next.