### PR TITLE
patch(index.js): Update config setting "proposalTimePastLimit"

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,7 +74,7 @@ if (argv.gasprice < 1 || argv.gasprice > 1000) throw "--gasprice must be between
     timelockLiveness: 86400, // 1 day
     maxFundingRate: { rawValue: web3.utils.toWei("0.00001") },
     minFundingRate: { rawValue: web3.utils.toWei("-0.00001") },
-    proposalTimePastLimit: 0
+    proposalTimePastLimit: 1800 // 30 minutes
   };
 
   const perpetualCreator = new web3.eth.Contract(


### PR DESCRIPTION
The `FundingRateApplier`'s `proposeFundingRate` method has this require constraint:

```
require(
            timestamp > updateTime && timestamp >= currentTime.sub(_getConfig().proposalTimePastLimit),
            “Invalid proposal time”
);
```

In English: the proposal timestamp must be GREATER than the last update time, and also GREATER than the current time minus some buffer period, the "proposalTimePastLimit".

The RHS of the require statement ensures that no proposer can propose prices too far in the past (i.e. we want "live" funding rates).

However, the OptimisticOracle also requires that all timestamps be in the past (can't propose timestamps in the future). Therefore, by setting `proposalTimePastLimit = 0`, you practically make it impossible to propose new rates because no stamps can satisfy the three following constraints:

1. Timestamp > `lastUpdateTime`  (`FundingRateApplier.proposeFundingRate()`)
2. Timestamp > currentTime (`FundingRateApplier.proposeFundingRate()`)
3. Timestamp <= currentTime (`OptimisticOracle.requestPrice()`)