### PR TITLE
improve(index.js)update ConfigStore params to recommended values for new Perpetuals

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,7 +71,7 @@ if (argv.gasprice < 1 || argv.gasprice > 1000) throw "--gasprice must be between
     sponsorDisputeRewardPercentage: { rawValue: toWei("0.05") }, // 5% reward for sponsors who are disputed invalidly
     disputerDisputeRewardPercentage: { rawValue: toWei("0.2") }, // 20% reward for correct disputes.
     minSponsorTokens: { rawValue: parseFixed(argv.minSponsorTokens.toString(), decimals) }, // Min sponsor position.
-    tokenScaling: { rawValue: toWei("3030") }, // Token scaling used to make initial token trade at 100: 100 / (e.g. current ETH/BTC) price.
+    tokenScaling: { rawValue: toWei("3060") }, // Token scaling used to make initial token trade at 100: 100 / (e.g. current ETH/BTC) price.
     liquidationLiveness: 7200, // 2 hour liquidation liveness.
     withdrawalLiveness: 7200 // 2 hour withdrawal liveness.
   };

--- a/index.js
+++ b/index.js
@@ -71,7 +71,7 @@ if (argv.gasprice < 1 || argv.gasprice > 1000) throw "--gasprice must be between
     sponsorDisputeRewardPercentage: { rawValue: toWei("0.05") }, // 5% reward for sponsors who are disputed invalidly
     disputerDisputeRewardPercentage: { rawValue: toWei("0.2") }, // 20% reward for correct disputes.
     minSponsorTokens: { rawValue: parseFixed(argv.minSponsorTokens.toString(), decimals) }, // Min sponsor position.
-    tokenScaling: { rawValue: toWei("1") }, // Token scaling.
+    tokenScaling: { rawValue: toWei("3030") }, // Token scaling used to make initial token trade at 100: 100 / (e.g. current ETH/BTC) price.
     liquidationLiveness: 7200, // 2 hour liquidation liveness.
     withdrawalLiveness: 7200 // 2 hour withdrawal liveness.
   };

--- a/index.js
+++ b/index.js
@@ -77,8 +77,12 @@ if (argv.gasprice < 1 || argv.gasprice > 1000) throw "--gasprice must be between
   };
 
   const configSettings = {
-    rewardRatePerSecond: { rawValue: "0" },
-    proposerBondPercentage: { rawValue: "0" },
+    rewardRatePerSecond: { rawValue: toWei("0.000000001") }, 
+    // Approximately 3%/year: 0.000000001*60*60*24*360 = 0.03
+    proposerBondPercentage: { rawValue: toWei("0.0007") }, 
+    // 0.07% is derived from a PfC of 300%/year = (300 / 360 / 24) = .035% / hour, and the minimum time that a proposal 
+    // can stay alive is 2 hours, so 0.07% is the minimum that should be staked by a proposer who might corrupt an
+    // entire 2 hour proposal liveness period.
     timelockLiveness: 86400, // 1 day
     maxFundingRate: { rawValue: web3.utils.toWei("0.00001") },
     minFundingRate: { rawValue: web3.utils.toWei("-0.00001") },
@@ -99,6 +103,7 @@ if (argv.gasprice < 1 || argv.gasprice > 1000) throw "--gasprice must be between
 
   // Simulate transaction to test before sending to the network.
   console.log("Simulating Deployment...");
+  console.log(`Calling PerpFactory @ ${perpetualCreator.options.address}`)
   const address = await perpetualCreator.methods.createPerpetual(perpetualParams, configSettings).call(transactionOptions);
   console.log("Simulation successful. Expected Address:", address);
 


### PR DESCRIPTION
- proposer bond: set to a value designed to deter a dishonest disputer from disputing proposals (and thereby maintaining a stale funding rate) that would earn them 300% in profit from corruption a year: 300% / 360 days / 24 hours = 0.035% / hour, proposal lives for minimum of 2 hours = 0.035% * 2 = 0.07%.
- reward rate per second: chosen to be small enough to minimize cost on sponsors, but > 0 to test incentives. Understand that this reward rate (pegged to 3%/year) results in rewards lower than cost of capital (i.e. gas fees) for smaller contracts but will scale as the contract gets larger.

Signed-off-by: Nick Pai <npai.nyc@gmail.com>